### PR TITLE
Fix Kotlin version conflicts by removing Spring dependency management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,4 @@
-import org.springframework.boot.gradle.plugin.SpringBootPlugin
-
 plugins {
-    id 'io.spring.dependency-management' version '1.1.7'
     id 'org.springframework.boot' version '4.0.5' apply false
     id 'org.jetbrains.kotlin.jvm' version '2.3.10' apply false
     id 'org.jetbrains.kotlin.plugin.spring' version '2.3.10' apply false
@@ -17,16 +14,13 @@ ext {
 allprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
-    apply plugin: 'io.spring.dependency-management'
 
     group = 'com.freberg'
     version = '0.0.1-SNAPSHOT'
 
-    dependencyManagement {
-        imports {
-            mavenBom(SpringBootPlugin.BOM_COORDINATES)
-            mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-        }
+    dependencies {
+        implementation platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
+        implementation platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}")
     }
 
     test {


### PR DESCRIPTION
Removes spring dependency-management plugin which causes conflicts with kotlin versions, see https://youtrack.jetbrains.com/issue/KT-85437